### PR TITLE
kustomize buildoptionはvaluesではなくmanifestからpatchを当てる

### DIFF
--- a/helm.tf
+++ b/helm.tf
@@ -12,9 +12,4 @@ resource "helm_release" "argocd" {
     name  = "configs.cm.create"
     value = "true"
   }
-
-  set {
-    name  = "configs.cm.kustomize.buildOptions"
-    value = "--enable-helm"
-  }
 }


### PR DESCRIPTION
ArgoCD導入時のhelmのvaluesでbuildOptionsを変更しようとすると
```yaml
apiVersion: v1
data:
  kustomize: 'map[buildOptions:--enable-helm]'
```
という形式で注入される。[manifest!133](https://github.com/honahuku/manifest/pull/133) で期待する値が注入されたのでterraform側での記述を消す